### PR TITLE
`Dockerfile` Fix yarn installation - the `apt-key` command has been deprecated and removed in recent Debian/Ubuntu versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG for 1.x
 ===================
+## v1.1.1 - (2025-08-18)
+### Fixed
+- `Dockerfile` Fix yarn installation - the `apt-key` command has been deprecated and removed in recent Debian/Ubuntu versions
+
 ## v1.1.0 - (2025-07-30)
 ### Changed
 - `.env` Update PHP_VERSION & NODE_VERSION vars to 8.4 and 22.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,9 @@ COPY --from=node /usr/local/bin/node /usr/local/bin/node
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 RUN node -v
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN sudo apt-get update && apt-get install --no-install-recommends -y yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/yarn-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/yarn-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install --no-install-recommends -y yarn
 
 # Cleaning
 RUN apt-get autoremove -y --purge \


### PR DESCRIPTION
Sources :
- [Debian Wiki - SecureApt](https://wiki.debian.org/SecureApt)